### PR TITLE
Fix Tauri build with Vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ npm install
 npm run tauri:build
 ```
 
+This script runs `vite build` to output the web assets under `dist/` before
+packaging the application with Tauri.
+
 The resulting binary will appear under `src-tauri/target/release/bundle/` for your platform.
 
 ## Service worker

--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
     "start": "http-server -p 8000",
     "lint": "eslint .",
     "format": "prettier --write .",
+    "build": "vite build",
     "update-holidays": "node scripts/update-holidays.js",
     "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build"
+    "tauri:build": "npm run build && tauri build"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.5.0",
+    "vite": "^5.2.12",
     "eslint": "^8.57.1",
     "http-server": "^14.1.1",
     "jest": "^29.6.1",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,9 +4,9 @@
   "version": "0.1.0",
   "identifier": "com.example.lmetrade",
   "build": {
-    "frontendDist": "../",
+    "frontendDist": "../dist",
     "beforeDevCommand": "",
-    "beforeBuildCommand": ""
+    "beforeBuildCommand": "npm run build"
   },
   "app": {
     "windows": [

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: '.',
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add a basic `vite` build setup
- run the vite build before packaging with Tauri
- update Tauri config to use the `dist` folder
- document the new build step in README

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68562252356c832ebcffa7d3c4c2c377